### PR TITLE
Fixed #36 - Metric being dropped during serialization

### DIFF
--- a/riemann/client.js
+++ b/riemann/client.js
@@ -73,7 +73,8 @@ function _defaultValues(payload) {
   if (!payload.host)  { payload.host = hostname; }
   if (!payload.time)  { payload.time = Math.round(new Date().getTime()/1000); }
   if (typeof payload.metric !== "undefined" && payload.metric !== null) {
-    payload.metric_f = payload.metric;
+    // protobufjs requires this to be camel case
+    payload.metricF = payload.metric;
     delete payload.metric;
   }
   return payload;


### PR DESCRIPTION
Protobufjs requires naming to be camelcase so replaced metric_f with metricF when building payload.

Signed-off-by: James Turnbull <james@lovedthanlost.net>